### PR TITLE
BUG: fix local .rmf files cannot be used properly

### DIFF
--- a/soxs/utils.py
+++ b/soxs/utils.py
@@ -309,10 +309,10 @@ def get_data_file(fn):
     soxs_data_dir = soxs_cfg.get("soxs", "soxs_data_dir")
     rel_fn = os.path.split(fn)[-1]
     data_fn = os.path.join(soxs_data_dir, rel_fn)
-    if os.path.exists(rel_fn):
+    if os.path.exists(fn):
         if rel_fn in finley._registry:
             mylog.warning(
-                "Using local file %s instead of the one from the database.", rel_fn
+                "Using local file %s instead of the one from the database.", fn
             )
         return fn
     elif rel_fn not in finley._registry and os.path.exists(data_fn):


### PR DESCRIPTION
Before this PR, `get_data_file(specfile, rmf="../anywhere/rmf_file.rmf)` would fail with `ValueError: File rmf_file.rmf is not in the registry.` because it ignore the relative/absolute path and only search in the current directory and `cache_data_dir`.