### PR TITLE
Fix PSF check in instrument_registry.py

### DIFF
--- a/soxs/instrument_registry.py
+++ b/soxs/instrument_registry.py
@@ -61,7 +61,7 @@ class InstrumentRegistry:
             else:
                 fns.append(bkgnd)
             logs.append("instrumental background model")
-        if inst_spec["psf"] is not None:
+        if "psf" in inst_spec and inst_spec["psf"] is not None:
             if "image" in inst_spec["psf"][0]:
                 fns.append(inst_spec["psf"][1])
                 logs.append("PSF model")


### PR DESCRIPTION
Using `fetch_files` for `"lynx_xgs"` or `"chandra_aciss_meg*"` will fail because there is no `psf` key for those instruments.

This commit checks if `psf` is in `inst_spec` before checking the value of `inst_spec['psf']`.

Alternatively, `"psf": None` could be added to all instruments where it is currently not present.